### PR TITLE
simplify/cleanup downloads page

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -5,73 +5,36 @@ permalink: /downloads/
 menu: main
 ---
 
-## Version 2020.4.0 Stable
+## Current version: 2020.4.0
+[Installer, release notes and source can be found on github](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2020.4.0)
 
-This is the current stable version. All bug reports should be based on this version.
-
-*  __Windows__
-   - [Installer](https://github.com/UltraStar-Deluxe/USDX/releases/download/v2020.4.0/UltraStar.Deluxe_v2020.4.0.stable_installer.exe)
-*  __Linux__
-   - [Build instructions](https://github.com/UltraStar-Deluxe/USDX#compiling-on-linuxbsd-using-make)
-*  __macOS__
-   - [Installer & Launcher](https://github.com/UltraStar-Deluxe/USDX/releases/download/v2020.4.0/UltraStar.Deluxe-v2020.4.0.stable_macOS.dmg)
+The most recent version.
+Bug reports should be based on this version.
 
 
-## Version 2017.8.0 Stable
-
-Changes from the 1.3 version are mostly bugfixes, stability updates, support for additional video & audio formats (up to ffmpeg 3.3) and general code cleanup.
-
-*  __Windows__
-   - [Installer](https://github.com/UltraStar-Deluxe/USDX/releases/download/v2017.8.0/UltraStar.Deluxe_v2017.8.0.stable_installer.exe)
-   - Please note: if your antimalware software says that this is possibly a virus, please feel free to tell your software provider to fix their shitty detection patterns. We are really annoyed of false positive reports, just because we also use the [NSIS 3 Installer](http://nsis.sourceforge.net/News) Also, feel free to upload that file to [virustotal.com](https://virustotal.com) - an online scanning service owned by Google Inc. that uses many different antimalware solutions.
-*  __Linux__
-   - [Build instructions](https://github.com/UltraStar-Deluxe/USDX#compiling-on-linuxbsd-using-make)
-   - [Archlinux Aur](https://aur.archlinux.org/packages/ultrastardx-git)
-*  __macOS__
-   - [Installer & Launcher](https://github.com/UltraStar-Deluxe/USDX/releases/download/v2017.8.0/UltraStar.Deluxe_v2017.8.0.stable.dmg)
+## Previous versions
+* [2017.8.0](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2017.8.0)
 
 
-## Version 1.3 (Beta 5)
-
-This is the 1.3 beta version of UltraStar Deluxe from 2016. Use this version if the above mentioned stable versions don't work for you.
-
-
-*  __Windows__
-   - [Installer](https://github.com/UltraStar-Deluxe/USDX/releases/download/v1.3.5-beta/UltraStar.Deluxe_v1.3.5.beta_installer.exe)
-*  __Linux__
-   - To be released
-   - [Build instructions](https://github.com/UltraStar-Deluxe/USDX#compiling-on-linuxbsd-using-make)
-   - [Archlinux Aur](https://aur.archlinux.org/packages/ultrastardx-git)
-*  __macOS__
-   - [Installer & Launcher](https://yaycdn.de/builds/osx/usdx/usdx_1_3_5_2017-02-27.dmg)
-
-## Version 1.1 (Final)
-
-This is the latest final version of UltraStar Deluxe from 2010.
-
-*  __Windows__
-   - [Installer](https://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/ultrastardx-1.1-installer-full.exe/)
-   - [Archive (ZIP)](https://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/ultrastardx-1.1-full.zip/download)
-*  __Linux__
-   - [Packages](https://launchpad.net/~tobydox/+archive/ultrastardx/+packages)
-   - [Ubuntu i386 deb](https://launchpad.net/~tobydox/+archive/ultrastardx/+files/ultrastar-deluxe_1.1.0-4_i386.deb)
-   - [Ubuntu amd64 deb](https://launchpad.net/~tobydox/+archive/ultrastardx/+files/ultrastar-deluxe_1.1.0-4_amd64.deb)
-*  __macOS__
-   - [Intel/PPC 10.5](http://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/UltraStarDeluxe-1.1.dmg/download)
-   - [PPC 10.4 only](http://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/UltraStarDeluxe-1.1%20%20%2810.4-PowerPC%29.dmg/download)
-*  __Source__
-   - [Source code archive (tar.gz)](http://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/Sources/ultrastardx-1.1-src.tar.gz/download)
-
-## Old Versions (Stable)
-
-### UltraStar Deluxe 1.0.1a (2007-12-23)
-
-*  [Windows Installer](http://downloads.sourceforge.net/ultrastardx/ultrastardx-101a-installer-full.exe)
-*  [Archive (ZIP)](http://downloads.sourceforge.net/ultrastardx/ultrastardx-101a-full.zip)
-*  [Archive (ZIP, without extra Songs and Themes)](http://downloads.sourceforge.net/ultrastardx/ultrastardx-101a-lite.zip)
-
-## Source Code Repository
-
-The source code repository for UltraStar Deluxe can be found at GitHub:  
-{% include icon-github.html username="Ultrastar-Deluxe" %} /
-[USDX](https://github.com/Ultrastar-Deluxe/USDX)
+## Very old versions
+* 1.3 (Beta 5) (2016):
+[release page](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v1.3.5-beta) -
+[Windows](https://github.com/UltraStar-Deluxe/USDX/releases/download/v1.3.5-beta/UltraStar.Deluxe_v1.3.5.beta_installer.exe) -
+[macOS](https://yaycdn.de/builds/osx/usdx/usdx_1_3_5_2017-02-27.dmg)
+* 1.1 (Final) (2010):
+  * Windows:
+    [Installer](https://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/ultrastardx-1.1-installer-full.exe/) -
+    [Archive (ZIP)](https://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/ultrastardx-1.1-full.zip/download)
+  * Linux:
+    [Packages](https://launchpad.net/~tobydox/+archive/ultrastardx/+packages) -
+    [Ubuntu i386 deb](https://launchpad.net/~tobydox/+archive/ultrastardx/+files/ultrastar-deluxe_1.1.0-4_i386.deb) -
+    [Ubuntu amd64 deb](https://launchpad.net/~tobydox/+archive/ultrastardx/+files/ultrastar-deluxe_1.1.0-4_amd64.deb)
+  * macOS:
+    [Intel/PPC 10.5](http://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/UltraStarDeluxe-1.1.dmg/download) -
+    [PPC 10.4 only](http://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/UltraStarDeluxe-1.1%20%20%2810.4-PowerPC%29.dmg/download)
+  * Source:
+    [Source code archive (tar.gz)](http://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/Sources/ultrastardx-1.1-src.tar.gz/download)
+* 1.0.1a (2007-12-23): Windows:
+  [installer](http://downloads.sourceforge.net/ultrastardx/ultrastardx-101a-installer-full.exe) -
+  [Archive (ZIP)](http://downloads.sourceforge.net/ultrastardx/ultrastardx-101a-full.zip) -
+  [Archive (ZIP, without extra Songs and Themes)](http://downloads.sourceforge.net/ultrastardx/ultrastardx-101a-lite.zip)


### PR DESCRIPTION
#12 part 1
once this is merged I'll create a follow-up PR to add the already released 2023.x versions

this technically introduces an extra step for the download process (clicking through the github release page) but maintaining a bunch of direct links to every single individual artifact is pain to maintain and just clutters the page. should I hear/see complaints about this, I'll re-introduce direct links for the current version (but not for previous versions)

"Previous versions" can, once the list gets long, easily be grouped per year, but that won't be relevant until at 2024 at the earliest.

I've also removed the bottom section on Source Code Repository, for there is already a separate development page, the releases point towards github, the current version even references it in the link. If people haven't found the source by then, I don't think a paragraph after the ancient versions will have any effect.