### PR TITLE
Backlogged releases

### DIFF
--- a/_posts/2023-03-05-release.md
+++ b/_posts/2023-03-05-release.md
@@ -1,0 +1,34 @@
+---
+layout: post
+title:  "v2023.3.0 released"
+date:   2023-03-05 20:09:00 +0200
+categories: news
+---
+Version 2023.3.0 has been released.
+Downloads are available from [github](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2023.3.0).
+
+## Features
+* Audio input through SDL #517 
+* Song Editor: change BPM value via F5 #617 
+
+## Enhancements
+* Improve song selection screen performance on large collections #534 
+* Improve video performance #530 #532 #628 
+* More logging during microphone detection #637 #641
+* Support for more special symbols #571
+
+## Bug Fixes
+* Fix some videos looping #521
+* Duet lyric colors regular/bold aren't hardcoded anymore #623 
+* Song Editor: fix line breaks sometimes being put in the wrong place #632 
+* Audio output through Jack SDL #654
+
+## Other Changes
+* FFmpeg support up to version 6 #583 #585 #601 #658
+* AppImage and Flatpak are automatically generated #565 
+* Various fixes #523 #563 #596 #613 #611 #639 #640 #642 #645 #649 #651 #652 #655 #653
+* Support Lua 5.4 #584
+* Update various credit assets #597
+
+The intention is to do more regular releases going forward!
+Probably around once a month, less if there's nothing that affects the end user, more if it's something big or a recent regression.

--- a/_posts/2023-04-01-release.md
+++ b/_posts/2023-04-01-release.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title:  "v2023.4.0 released"
+date:   2023-04-01 20:09:00 +0200
+categories: news
+---
+Version 2023.4.0 has been released.
+Downloads are available from [github](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2023.4.0).
+
+## Enhancements
+* Improved French translation #541 
+* Videos now use letterbox/pillarbox by default. Can be changed with `A` #562 #667 
+* Add some audio and video extensions to the editor #664 
+
+## Bug Fixes
+* Fix progress bar when using `#START` values (and also draw lyric info during medleys) #618 
+* Improve random song selection when using chessboard or tile mode #665 
+
+## Other Changes
+* Refactoring #627 

--- a/_posts/2023-05-02-release.md
+++ b/_posts/2023-05-02-release.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title:  "v2023.5.0 released"
+date:   2023-05-02 20:09:00 +0200
+categories: news
+---
+Version 2023.5.0 has been released.
+Downloads are available from [github](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2023.5.0)
+and [flathub](https://flathub.org/apps/eu.usdx.UltraStarDeluxe).
+
+## Enhancements
+* Use song preview volume also for menu background music volume #670
+
+## Bug Fixes
+* Fix OpenCV (webcam) on old devices #657
+
+## Other Changes
+* Refactoring #672
+* Update compilation documentation #668
+* AppImage updates #659 #682

--- a/downloads.md
+++ b/downloads.md
@@ -16,7 +16,7 @@ Bug reports should be based on this version.
 * [2017.8.0](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2017.8.0)
 
 
-## Very old versions
+### Very old versions
 * 1.3 (Beta 5) (2016):
 [release page](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v1.3.5-beta) -
 [Windows](https://github.com/UltraStar-Deluxe/USDX/releases/download/v1.3.5-beta/UltraStar.Deluxe_v1.3.5.beta_installer.exe) -

--- a/downloads.md
+++ b/downloads.md
@@ -11,6 +11,10 @@ menu: main
 The most recent version.
 Bug reports should be based on this version.
 
+Alternative installation methods:
+[flathub](https://flathub.org/apps/eu.usdx.UltraStarDeluxe) -
+[AUR](https://aur.archlinux.org/packages/ultrastardx-git)
+
 
 ## Previous versions
 * [2023.4.0](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2023.4.0)

--- a/downloads.md
+++ b/downloads.md
@@ -5,14 +5,17 @@ permalink: /downloads/
 menu: main
 ---
 
-## Current version: 2020.4.0
-[Installer, release notes and source can be found on github](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2020.4.0)
+## Current version: 2023.5.0
+[Installer, release notes and source can be found on github](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2023.5.0).
 
 The most recent version.
 Bug reports should be based on this version.
 
 
 ## Previous versions
+* [2023.4.0](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2023.4.0)
+* [2023.3.0](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2023.3.0)
+* [2020.4.0](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2020.4.0)
 * [2017.8.0](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v2017.8.0)
 
 


### PR DESCRIPTION
this PR adds:
- make the "Very old versions" a subheader of "Previous versions"
- adds 3 releases (to download page + 3 newsposts)
- download page: added two alternative installation locations: flathub + AUR

This PR closes #12 (it's part 2, after this it'll just be the ~monthly updates)