### PR TITLE
remove link that no longer works

### DIFF
--- a/downloads.md
+++ b/downloads.md
@@ -49,7 +49,7 @@ Alternative installation methods:
 * 1.3 (Beta 5) (2016):
 [release page](https://github.com/UltraStar-Deluxe/USDX/releases/tag/v1.3.5-beta) -
 [Windows](https://github.com/UltraStar-Deluxe/USDX/releases/download/v1.3.5-beta/UltraStar.Deluxe_v1.3.5.beta_installer.exe) -
-[macOS](https://yaycdn.de/builds/osx/usdx/usdx_1_3_5_2017-02-27.dmg)
+~~macOS~~
 * 1.1 (Final) (2010):
   * Windows:
     [Installer](https://sourceforge.net/projects/ultrastardx/files/UltraStar%20Deluxe/Version%201.1%20final/ultrastardx-1.1-installer-full.exe/) -


### PR DESCRIPTION
the macOS link for 1.3 no longer works. there's little point in trying to find it back and host it elsewhere, these days the builds are properly automated anyway.

fixes https://github.com/UltraStar-Deluxe/USDX/issues/519

NB I have no idea if the website renderer will understand the `~~strikethrough~~` formatting. I don't see why it _wouldn't_ but it's so ancient I've never been able to get it working locally.